### PR TITLE
Fix XP Calculation

### DIFF
--- a/src/main/java/xyz/oribuin/xpbottles/command/BottleCommand.kt
+++ b/src/main/java/xyz/oribuin/xpbottles/command/BottleCommand.kt
@@ -56,7 +56,7 @@ class BottleCommand(private val plugin: XPBottles) : Command(plugin) {
         }
 
         // Check if the sender has enough xp to do it
-        if (sender.totalExperience < this.plugin.config.getInt("min-xp")) {
+        if (plugin.getTotalXp(sender) < this.plugin.config.getInt("min-xp")) {
             this.msg.send(sender, "not-enough-xp")
             return
         }
@@ -72,13 +72,13 @@ class BottleCommand(private val plugin: XPBottles) : Command(plugin) {
             return
         }
 
-        if(sender.totalExperience < amount) {
+        if(plugin.getTotalXp(sender) < amount) {
             this.msg.send(sender, "not-enough-xp")
             return
         }
 
         val bottle = this.plugin.createBottle(amount, sender)
-        sender.giveExp(-amount)
+        plugin.setXp(sender, plugin.getTotalXp(sender) -amount)
         this.msg.send(sender, "withdrew-xp", StringPlaceholders.single("xp", plugin.formatNum(amount)))
         if (sender.inventory.firstEmpty() == -1) {
             this.msg.send(sender, "dropped-xp-bottle")

--- a/src/main/java/xyz/oribuin/xpbottles/listener/ThrowListener.kt
+++ b/src/main/java/xyz/oribuin/xpbottles/listener/ThrowListener.kt
@@ -24,7 +24,7 @@ class ThrowListener(private val plugin: XPBottles) : Listener {
         val container = itemMeta.persistentDataContainer
 
         val xpAmount = container.get(plugin.key, PersistentDataType.INTEGER) ?: return
-        player.giveExp(xpAmount)
+        plugin.setXp(this.player, this.player.totalExperience + xpAmount)
         item.amount = item.amount - 1
         plugin.getManager(MessageManager::class.java).send(player, "gained-xp", StringPlaceholders.single("xp", plugin.formatNum(xpAmount)))
         this.isCancelled = true


### PR DESCRIPTION
getTotalXp gets the total amount of XP, meaning that players could withdraw more than they currently have. 
Added the math to get and set the accurate amount of XP as can be found [here](https://minecraft.fandom.com/wiki/Experience)